### PR TITLE
feat: 3주차 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    // database-h2
-    runtimeOnly 'com.h2database:h2'
+    // database-mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-    //test-junit
+    // test-junit
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/sopt/homework/controller/PostController.java
+++ b/src/main/java/org/sopt/homework/controller/PostController.java
@@ -1,9 +1,9 @@
 package org.sopt.homework.controller;
 
-import java.util.List;
-
-import org.sopt.homework.dto.PostRequest;
-import org.sopt.homework.dto.PostResponse;
+import org.sopt.homework.dto.post.request.PostWriteRequest;
+import org.sopt.homework.dto.post.response.PostDetailResponse;
+import org.sopt.homework.dto.post.response.PostListResponse;
+import org.sopt.homework.global.api.message.ResponseMessage;
 import org.sopt.homework.service.PostService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,39 +27,48 @@ public class PostController {
 
 	// 게시글 생성
 	@PostMapping
-	public PostResponse createPost(@RequestBody final PostRequest postRequestDto) {
-		return postService.createPost(postRequestDto);
+	public ResponseMessage createPost(
+		@RequestHeader(name = "userId", required = true) final long userId,
+		@RequestBody final PostWriteRequest postWriteRequestDto) {
+		postService.createPost(userId, postWriteRequestDto);
+		return ResponseMessage.POST_CREATED;
 	}
 
 	// 게시글 조회
 	@GetMapping
-	public List<PostResponse> getPosts() {
+	public PostListResponse getPosts() {
 		// 쿼리스트링으로 키워드가 전달되면 검색을 진행, 키워드가 전달되지 않으면 전체 게시글을 조회
 		return postService.getAllPosts();
 	}
 
-	// 게시글 검색
 	@GetMapping(path = "/search")
-	public List<PostResponse> searchPosts(@RequestParam(value = "keyword") final String keyword) {
-		return postService.getPostsByTitle(keyword);
+	public PostListResponse searchPosts(
+		@RequestParam(name = "author", required = false) final String author,
+		@RequestParam(name = "title", required = false) final String title,
+		@RequestParam(name = "tag", required = false) final String tagName
+	) {
+		return postService.searchPosts(author, title, tagName);
 	}
 
 	// 게시글 상세 조회
 	@GetMapping(path = "/{postId}")
-	public PostResponse getPostById(@PathVariable(value = "postId") final Long id) {
-		return postService.getPostById(id);
+	public PostDetailResponse getPostById(@PathVariable(value = "postId") final long postId) {
+		return postService.getPostById(postId);
 	}
 
-	// 게시글 제목 수정
+	// 게시글 수정
 	@PutMapping(path = "/{postId}")
-	public void updatePostTitle(@PathVariable(value = "postId") final Long id,
-		@RequestBody final PostRequest postRequestDto) {
-		postService.updatePost(id, postRequestDto);
+	public void updatePostTitle(
+		@RequestHeader(name = "userId", required = true) final long userId,
+		@PathVariable(value = "postId") final long postId,
+		@RequestBody final PostWriteRequest postWriteRequestDto) {
+		postService.updatePost(postId, userId, postWriteRequestDto);
 	}
 
 	// 게시글 삭제
 	@DeleteMapping(path = "/{postId}")
-	public void deletePostById(@PathVariable(value = "postId") final Long id) {
-		postService.deletePostById(id);
+	public ResponseMessage deletePostById(@PathVariable(value = "postId") final long postId) {
+		postService.deletePostById(postId);
+		return ResponseMessage.POST_DELETED;
 	}
 }

--- a/src/main/java/org/sopt/homework/controller/PostController.java
+++ b/src/main/java/org/sopt/homework/controller/PostController.java
@@ -29,7 +29,8 @@ public class PostController {
 	@PostMapping
 	public ResponseMessage createPost(
 		@RequestHeader(name = "userId", required = true) final long userId,
-		@RequestBody final PostWriteRequest postWriteRequestDto) {
+		@RequestBody final PostWriteRequest postWriteRequestDto
+	) {
 		postService.createPost(userId, postWriteRequestDto);
 		return ResponseMessage.POST_CREATED;
 	}
@@ -61,14 +62,18 @@ public class PostController {
 	public void updatePostTitle(
 		@RequestHeader(name = "userId", required = true) final long userId,
 		@PathVariable(value = "postId") final long postId,
-		@RequestBody final PostWriteRequest postWriteRequestDto) {
+		@RequestBody final PostWriteRequest postWriteRequestDto
+	) {
 		postService.updatePost(postId, userId, postWriteRequestDto);
 	}
 
 	// 게시글 삭제
 	@DeleteMapping(path = "/{postId}")
-	public ResponseMessage deletePostById(@PathVariable(value = "postId") final long postId) {
-		postService.deletePostById(postId);
+	public ResponseMessage deletePostById(
+		@RequestHeader(name = "userId", required = true) final long userId,
+		@PathVariable(value = "postId") final long postId
+	) {
+		postService.deletePostById(userId, postId);
 		return ResponseMessage.POST_DELETED;
 	}
 }

--- a/src/main/java/org/sopt/homework/controller/UserController.java
+++ b/src/main/java/org/sopt/homework/controller/UserController.java
@@ -1,0 +1,23 @@
+package org.sopt.homework.controller;
+
+import org.sopt.homework.dto.user.UserSignupRequest;
+import org.sopt.homework.service.UserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/users")
+public class UserController {
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@PostMapping("/signup")
+	public void create(@RequestBody final UserSignupRequest userSignupRequest) {
+		userService.createUser(userSignupRequest);//response로 아이디랑 이름 추가하기, 201로 바꾸기
+	}
+}

--- a/src/main/java/org/sopt/homework/controller/UserController.java
+++ b/src/main/java/org/sopt/homework/controller/UserController.java
@@ -2,8 +2,10 @@ package org.sopt.homework.controller;
 
 import org.sopt.homework.dto.user.UserSignupRequest;
 import org.sopt.homework.service.UserService;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +20,11 @@ public class UserController {
 
 	@PostMapping("/signup")
 	public void create(@RequestBody final UserSignupRequest userSignupRequest) {
-		userService.createUser(userSignupRequest);//response로 아이디랑 이름 추가하기, 201로 바꾸기
+		userService.createUser(userSignupRequest);
+	}
+
+	@DeleteMapping
+	public void delete(@RequestHeader(name = "userId", required = true) final long userId) {
+		userService.deleteUser(userId);
 	}
 }

--- a/src/main/java/org/sopt/homework/controller/UserController.java
+++ b/src/main/java/org/sopt/homework/controller/UserController.java
@@ -1,6 +1,7 @@
 package org.sopt.homework.controller;
 
 import org.sopt.homework.dto.user.UserSignupRequest;
+import org.sopt.homework.global.api.message.ResponseMessage;
 import org.sopt.homework.service.UserService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,12 +20,14 @@ public class UserController {
 	}
 
 	@PostMapping("/signup")
-	public void create(@RequestBody final UserSignupRequest userSignupRequest) {
+	public ResponseMessage create(@RequestBody final UserSignupRequest userSignupRequest) {
 		userService.createUser(userSignupRequest);
+		return ResponseMessage.POST_CREATED;
 	}
 
 	@DeleteMapping
-	public void delete(@RequestHeader(name = "userId", required = true) final long userId) {
+	public ResponseMessage delete(@RequestHeader(name = "userId", required = true) final long userId) {
 		userService.deleteUser(userId);
+		return ResponseMessage.POST_DELETED;
 	}
 }

--- a/src/main/java/org/sopt/homework/domain/Post.java
+++ b/src/main/java/org/sopt/homework/domain/Post.java
@@ -3,15 +3,22 @@ package org.sopt.homework.domain;
 import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.sopt.homework.domain.util.Tag;
 import org.sopt.homework.domain.util.validator.Validator;
 import org.sopt.homework.global.exception.GlobalException;
 import org.sopt.homework.global.exception.message.ExceptionMessage;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
@@ -20,26 +27,44 @@ public final class Post {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "post_id", nullable = false, unique = true, updatable = false)
-	private Long id;
+	private long id;
 
 	// 이모지만 30개 넣으면 varChar 기본 크기인 255바이트가 모자랄 수 있음
 	@Column(name = "title", nullable = false, length = 1024)
 	private String title;
 
+	// 이모지만 1000자인 경우에 varchar의 최대길이를 넘어갈 수 있으므로 text로 설정
+	@Lob
+	@Column(name = "content", columnDefinition = "TEXT", nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "tag")
+	private Tag tag;
+
 	@CreationTimestamp
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-	public Post(String title) {
+	// ON DELETE SET NULL 제약조건 적용됨
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User author;
+
+	public Post(String title, String content, String tagName, User author) {
 		// 검증 결과에 따라 예외처리
 		validateTitle(title);
+		validateContent(content);
 		this.title = title;
+		this.content = content;
+		this.tag = Tag.fromString(tagName);
+		this.author = author;
 	}
 
-	public Post() {
+	protected Post() {
 	}
 
-	public Long getId() {
+	public long getId() {
 		return this.id;
 	}
 
@@ -47,20 +72,55 @@ public final class Post {
 		return this.title;
 	}
 
-	// 게시글 수정 시 사용되는 update 메서드
+	public String getContent() {
+		return this.content;
+	}
+
+	public Tag getTag() {
+		return this.tag;
+	}
+
+	public User getAuthor() {
+		return this.author;
+	}
+
+	// 게시글 제목 수정
 	public void updateTitle(String title) {
 		validateTitle(title);
 		this.title = title;
+	}
+
+	// 게시글 내용 수정
+	public void updateContent(String content) {
+		validateContent(content);
+		this.content = content;
+	}
+
+	// 게시글 태그 수정
+	public void updateTag(String tagName) {
+		this.tag = Tag.fromString(tagName);
 	}
 
 	private void validateTitle(String title) {
 		if (title == null) {
 			throw new GlobalException(ExceptionMessage.BAD_REQUEST);
 		}
-		if (Validator.isEmptyTitle(title)) {
+		if (Validator.isEmpty(title)) {
 			throw new GlobalException(ExceptionMessage.EMPTY_TITLE);
 		}
-		if (Validator.isOverLengthTitle(title)) {
+		if (Validator.isOverLength(title, 30)) {
+			throw new GlobalException((ExceptionMessage.OVER_LENGTH_TITLE));
+		}
+	}
+
+	private void validateContent(String content) {
+		if (content == null) {
+			throw new GlobalException(ExceptionMessage.BAD_REQUEST);
+		}
+		if (Validator.isEmpty(content)) {
+			throw new GlobalException(ExceptionMessage.EMPTY_TITLE);
+		}
+		if (Validator.isOverLength(content, 1000)) {
 			throw new GlobalException((ExceptionMessage.OVER_LENGTH_TITLE));
 		}
 	}

--- a/src/main/java/org/sopt/homework/domain/User.java
+++ b/src/main/java/org/sopt/homework/domain/User.java
@@ -1,0 +1,52 @@
+package org.sopt.homework.domain;
+
+import org.sopt.homework.domain.util.validator.Validator;
+import org.sopt.homework.global.exception.GlobalException;
+import org.sopt.homework.global.exception.message.ExceptionMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "user")
+public final class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false, unique = true, updatable = false)
+	private long id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	public User(String name) {
+		validateName(name);
+		this.name = name;
+	}
+
+	protected User() {
+	}
+
+	public long getId() {
+		return this.id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	private void validateName(String name) {
+		if (name == null) {
+			throw new GlobalException(ExceptionMessage.BAD_REQUEST);
+		}
+		if (Validator.isEmpty(name)) {
+			throw new GlobalException(ExceptionMessage.EMPTY_NAME);
+		}
+		if (Validator.isOverLength(name, 10)) {
+			throw new GlobalException(ExceptionMessage.OVER_LENGTH_NAME);
+		}
+	}
+}

--- a/src/main/java/org/sopt/homework/domain/util/Tag.java
+++ b/src/main/java/org/sopt/homework/domain/util/Tag.java
@@ -1,0 +1,29 @@
+package org.sopt.homework.domain.util;
+
+import java.util.Arrays;
+
+import org.sopt.homework.global.exception.GlobalException;
+import org.sopt.homework.global.exception.message.ExceptionMessage;
+
+public enum Tag {
+	BACKEND("백엔드"),
+	DATABASE("데이터베이스"),
+	INFRASTRUCTURE("인프라");
+
+	private final String tagName;
+
+	Tag(String tagName) {
+		this.tagName = tagName;
+	}
+
+	public static Tag fromString(String tagName) {
+		return Arrays.stream(Tag.values())
+			.filter(tag -> tag.tagName.equalsIgnoreCase(tagName))
+			.findFirst()
+			.orElseThrow(() -> new GlobalException(ExceptionMessage.INVALID_TAG_NAME));
+	}
+
+	public String getTagName() {
+		return this.tagName;
+	}
+}

--- a/src/main/java/org/sopt/homework/domain/util/validator/Validator.java
+++ b/src/main/java/org/sopt/homework/domain/util/validator/Validator.java
@@ -7,16 +7,16 @@ public class Validator {
 	// 하나의 시각적 유니코드 grapheme의 정규식인 "\X"를 이용하여 문자열의 길이를 카운트
 	private static final Pattern GRAPHEME_PATTERN = Pattern.compile("\\X");
 
-	public static boolean isEmptyTitle(String title) {
-		return title.isBlank();
+	public static boolean isEmpty(String string) {
+		return string.isBlank();
 	}
 
-	public static boolean isOverLengthTitle(String title) {
-		return lengthWithEmoji(title) > 30;
+	public static boolean isOverLength(String string, int maxLength) {
+		return lengthWithEmoji(string) > maxLength;
 	}
 
-	private static int lengthWithEmoji(String title) {
-		Matcher matcher = GRAPHEME_PATTERN.matcher(title);
+	private static int lengthWithEmoji(String string) {
+		Matcher matcher = GRAPHEME_PATTERN.matcher(string);
 		int count = 0;
 
 		while (matcher.find()) {

--- a/src/main/java/org/sopt/homework/dto/PostRequest.java
+++ b/src/main/java/org/sopt/homework/dto/PostRequest.java
@@ -1,9 +1,0 @@
-package org.sopt.homework.dto;
-
-import org.sopt.homework.domain.Post;
-
-public record PostRequest(String title) {
-	public Post toEntity() {
-		return new Post(this.title);
-	}
-}

--- a/src/main/java/org/sopt/homework/dto/PostResponse.java
+++ b/src/main/java/org/sopt/homework/dto/PostResponse.java
@@ -1,9 +1,0 @@
-package org.sopt.homework.dto;
-
-import org.sopt.homework.domain.Post;
-
-public record PostResponse(Long id, String title) {
-	public static PostResponse of(Post post) {
-		return new PostResponse(post.getId(), post.getTitle());
-	}
-}

--- a/src/main/java/org/sopt/homework/dto/post/request/PostWriteRequest.java
+++ b/src/main/java/org/sopt/homework/dto/post/request/PostWriteRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.homework.dto.post.request;
+
+import org.sopt.homework.domain.Post;
+import org.sopt.homework.domain.User;
+
+public record PostRequest(String title, String content, String tagName) {
+	public Post toEntity(User user) {
+		return new Post(this.title, this.content, this.tagName, user);
+	}
+}

--- a/src/main/java/org/sopt/homework/dto/post/request/PostWriteRequest.java
+++ b/src/main/java/org/sopt/homework/dto/post/request/PostWriteRequest.java
@@ -3,7 +3,7 @@ package org.sopt.homework.dto.post.request;
 import org.sopt.homework.domain.Post;
 import org.sopt.homework.domain.User;
 
-public record PostRequest(String title, String content, String tagName) {
+public record PostWriteRequest(String title, String content, String tagName) {
 	public Post toEntity(User user) {
 		return new Post(this.title, this.content, this.tagName, user);
 	}

--- a/src/main/java/org/sopt/homework/dto/post/response/PostDetailResponse.java
+++ b/src/main/java/org/sopt/homework/dto/post/response/PostDetailResponse.java
@@ -1,0 +1,25 @@
+package org.sopt.homework.dto.post.response;
+
+import org.sopt.homework.domain.Post;
+
+public record PostDetailResponse(
+	long id,
+	String title,
+	String content,
+	String tagName,
+	String author
+) {
+	public static PostDetailResponse of(Post post) {
+		String author = null;
+		if (post.getAuthor() != null) {
+			author = post.getAuthor().getName();
+		}
+		return new PostDetailResponse(
+			post.getId(),
+			post.getTitle(),
+			post.getContent(),
+			post.getTag().getTagName(),
+			author
+		);
+	}
+}

--- a/src/main/java/org/sopt/homework/dto/post/response/PostListResponse.java
+++ b/src/main/java/org/sopt/homework/dto/post/response/PostListResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.homework.dto.post.response;
+
+import java.util.List;
+
+import org.sopt.homework.domain.Post;
+
+public record PostListResponse(
+	List<PostListElement> posts
+) {
+	public static PostListResponse of(List<Post> posts) {
+		return new PostListResponse(posts.stream().map(PostListElement::of).toList());
+	}
+
+	public record PostListElement(
+		long id,
+		String title,
+		String author
+	) {
+		public static PostListElement of(Post post) {
+			String author = null;
+			if (post.getAuthor() != null) {
+				author = post.getAuthor().getName();
+			}
+			return new PostListElement(
+				post.getId(),
+				post.getTitle(),
+				author
+			);
+		}
+	}
+}

--- a/src/main/java/org/sopt/homework/dto/user/UserSignupRequest.java
+++ b/src/main/java/org/sopt/homework/dto/user/UserSignupRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.homework.dto.user;
+
+import org.sopt.homework.domain.User;
+
+public record UserSignupRequest(String name) {
+	public User toEntity() {
+		return new User(this.name);
+	}
+}

--- a/src/main/java/org/sopt/homework/global/api/advice/ApiResponseAdvice.java
+++ b/src/main/java/org/sopt/homework/global/api/advice/ApiResponseAdvice.java
@@ -1,11 +1,9 @@
 package org.sopt.homework.global.api.advice;
 
-import org.sopt.homework.dto.PostResponse;
 import org.sopt.homework.global.api.message.ResponseMessage;
 import org.sopt.homework.global.api.response.ErrorResponse;
 import org.sopt.homework.global.api.response.SuccessfulResponse;
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
@@ -31,16 +29,15 @@ public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
 			return body;
 		}
 
-		// 삭제 요청에 대한 응답 상태 코드 설정
-		if (request.getMethod().equals(HttpMethod.DELETE)) {
-			response.setStatusCode(ResponseMessage.DELETED.getHttpStatus());
-			return SuccessfulResponse.of(ResponseMessage.DELETED, body);
+		// 이미 응답 형태로 감싸진 경우 바로 body를 반환
+		if (body instanceof SuccessfulResponse) {
+			return body;
 		}
 
-		// 생성 요청에 대한 응답 상태 코드 설정
-		if (request.getMethod().equals(HttpMethod.POST) && returnType.getParameterType().equals(PostResponse.class)) {
-			response.setStatusCode(ResponseMessage.CREATED.getHttpStatus());
-			return SuccessfulResponse.of(ResponseMessage.CREATED, body);
+		// 반환 형태가 ResponseMessage인 경우 해당되는 응답 코드 적용 및 형태 적용
+		if (body instanceof ResponseMessage responseMessage) {
+			response.setStatusCode(responseMessage.getHttpStatus());
+			return SuccessfulResponse.of(responseMessage, null);
 		}
 
 		return SuccessfulResponse.of(ResponseMessage.SUCCESS, body);

--- a/src/main/java/org/sopt/homework/global/api/message/ResponseMessage.java
+++ b/src/main/java/org/sopt/homework/global/api/message/ResponseMessage.java
@@ -4,9 +4,11 @@ import org.springframework.http.HttpStatus;
 
 public enum ResponseMessage {
 	SUCCESS(HttpStatus.OK, "s2000", "요청이 성공했습니다."),
-	CREATED(HttpStatus.CREATED, "s2010", "게시글이 생성되었습니다."),
-	UPDATED(HttpStatus.OK, "s2000", "게시글이 수정되었습니다."),
-	DELETED(HttpStatus.OK, "s2000", "게시글이 삭제되었습니다.");
+	POST_CREATED(HttpStatus.CREATED, "s2010", "게시글이 생성되었습니다."),
+	USER_CREATED(HttpStatus.CREATED, "s2011", "회원가입이 완료되었습니다."),
+	UPDATED(HttpStatus.OK, "s2001", "게시글이 수정되었습니다."),
+	POST_DELETED(HttpStatus.OK, "s2002", "게시글이 삭제되었습니다."),
+	USER_DELETED(HttpStatus.OK, "s2003", "회원탈퇴가 완료되었습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String subCode;

--- a/src/main/java/org/sopt/homework/global/exception/message/ExceptionMessage.java
+++ b/src/main/java/org/sopt/homework/global/exception/message/ExceptionMessage.java
@@ -5,9 +5,14 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionMessage {
 	EMPTY_TITLE(HttpStatus.BAD_REQUEST, "c4001", "제목이 비어있습니다."),
 	OVER_LENGTH_TITLE(HttpStatus.BAD_REQUEST, "c4002", "제목은 30글자를 넘을 수 없습니다."),
-	BAD_REQUEST(HttpStatus.BAD_REQUEST, "c4050", "잘못된 HTTP method 요청입니다."),
+	INVALID_TAG_NAME(HttpStatus.BAD_REQUEST, "c4003", "잘못된 태그명입니다."),
+	EMPTY_NAME(HttpStatus.BAD_REQUEST, "c4004", "이름이 비어있습니다."),
+	OVER_LENGTH_NAME(HttpStatus.BAD_REQUEST, "c4005", "이름은 10글자를 넘을 수 없습니다."),
+	INVALID_AUTHOR(HttpStatus.FORBIDDEN, "c4030", "게시글을 수정할 수 있는 권한이 없습니다."),
+	BAD_REQUEST(HttpStatus.METHOD_NOT_ALLOWED, "c4050", "잘못된 HTTP method 요청입니다."),
 	EXIST_TITLE(HttpStatus.CONFLICT, "c4090", "이미 존재하는 게시글입니다."),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "c4041", "존재하지 않는 게시물입니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c4042", "사용자 정보가 존재하지 않습니다."),
 	CREATION_TIME_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "c4291", "아직 게시글을 작성할 수 없습니다"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s5000", "서버 내부 오류입니다.");
 

--- a/src/main/java/org/sopt/homework/repository/PostRepository.java
+++ b/src/main/java/org/sopt/homework/repository/PostRepository.java
@@ -7,12 +7,11 @@ import java.util.Optional;
 import org.sopt.homework.domain.Post;
 import org.sopt.homework.domain.util.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
+public interface PostRepository extends JpaRepository<Post, Long> {
 	// 가장 최근에 작성된 게시글의 작성 시각 조회
 	@Query("SELECT MAX(p.createdAt) FROM Post p")
 	Optional<LocalDateTime> findCurrentCreatedAt();

--- a/src/main/java/org/sopt/homework/repository/PostRepository.java
+++ b/src/main/java/org/sopt/homework/repository/PostRepository.java
@@ -20,13 +20,16 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
 	// 이미 존재하는 게시글 제목인지 판별
 	boolean existsByTitle(String title);
 
+	@Query("SELECT p FROM Post p LEFT JOIN p.author WHERE p.id = :postId")
+	Optional<Post> findById(@Param("postId") long postId);
+
 	// 게시글 전체 목록 최신순 조회
 	@Query("SELECT p FROM Post p LEFT JOIN p.author u ORDER BY p.createdAt DESC")
 	List<Post> findAllByOrderByCreatedAtDesc();
 
 	// 연관관계 제거 반영을 위한 벌크 연산
 	@Modifying
-	@Query("UPDATE Post p SET p.author = null where p.author.id = :userId")
+	@Query("UPDATE Post p SET p.author = NULL WHERE p.author.id = :userId")
 	void removeAuthor(@Param("userId") long userId);
 
 	// 검색 조건에 따라 검색, 키원드가 전부 null이거나 빈 문자열이면 전체 리스트를 반환

--- a/src/main/java/org/sopt/homework/repository/PostRepository.java
+++ b/src/main/java/org/sopt/homework/repository/PostRepository.java
@@ -5,14 +5,41 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sopt.homework.domain.Post;
+import org.sopt.homework.domain.util.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
+	// 가장 최근에 작성된 게시글의 작성 시각 조회
 	@Query("SELECT MAX(p.createdAt) FROM Post p")
 	Optional<LocalDateTime> findCurrentCreatedAt();
 
+	// 이미 존재하는 게시글 제목인지 판별
 	boolean existsByTitle(String title);
 
-	List<Post> findByTitleContaining(String title);
+	// 게시글 전체 목록 최신순 조회
+	@Query("SELECT p FROM Post p LEFT JOIN p.author u ORDER BY p.createdAt DESC")
+	List<Post> findAllByOrderByCreatedAtDesc();
+
+	// 연관관계 제거 반영을 위한 벌크 연산
+	@Modifying
+	@Query("UPDATE Post p SET p.author = null where p.author.id = :userId")
+	void removeAuthor(@Param("userId") long userId);
+
+	// 검색 조건에 따라 검색, 키원드가 전부 null이거나 빈 문자열이면 전체 리스트를 반환
+	@Query("""
+		    SELECT p FROM Post p
+		    LEFT JOIN p.author u
+		    WHERE (:title IS NULL OR :title = '' OR p.title LIKE CONCAT('%', :title, '%'))
+		      AND (:author IS NULL OR :author = '' OR u.name LIKE CONCAT('%', :author, '%'))
+		      AND (:tag IS NULL OR p.tag = :tag)
+		    ORDER BY p.createdAt DESC
+		""")
+	List<Post> findByOptionsOrderByCreatedAtDesc(
+		@Param("author") String author,
+		@Param("title") String title,
+		@Param("tag") Tag tag);
 }

--- a/src/main/java/org/sopt/homework/repository/UserRepository.java
+++ b/src/main/java/org/sopt/homework/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.homework.repository;
+
+import org.sopt.homework.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsById(long id);
+}

--- a/src/main/java/org/sopt/homework/service/PostService.java
+++ b/src/main/java/org/sopt/homework/service/PostService.java
@@ -97,8 +97,15 @@ public class PostService {
 
 	// 게시글 삭제
 	@Transactional
-	public void deletePostById(final long postId) {
-		postRepository.deleteById(postId);
+	public void deletePostById(final long userId, final long postId) {
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new GlobalException(ExceptionMessage.POST_NOT_FOUND));
+
+		if (post.getAuthor() == null || post.getAuthor().getId() != userId) {
+			throw new GlobalException(ExceptionMessage.INVALID_AUTHOR);
+		}
+
+		postRepository.deleteById(postId); // 유효한 사용자인지 검증 하는 로직 추가
 	}
 
 	// 유저 엔티티의 프록시 객체 생성

--- a/src/main/java/org/sopt/homework/service/UserService.java
+++ b/src/main/java/org/sopt/homework/service/UserService.java
@@ -1,6 +1,7 @@
 package org.sopt.homework.service;
 
 import org.sopt.homework.dto.user.UserSignupRequest;
+import org.sopt.homework.repository.PostRepository;
 import org.sopt.homework.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,13 +10,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 	private final UserRepository userRepository;
+	private final PostRepository postRepository;
 
-	public UserService(UserRepository userRepository) {
+	public UserService(UserRepository userRepository, PostRepository postRepository) {
 		this.userRepository = userRepository;
+		this.postRepository = postRepository;
 	}
 
 	@Transactional
 	public void createUser(UserSignupRequest userSignupRequest) {
 		userRepository.save(userSignupRequest.toEntity());
+	}
+
+	@Transactional
+	public void deleteUser(long userId) {
+		// 게시글과 유저의 연관관계 먼저 제거
+		postRepository.removeAuthor(userId);
+
+		// 유저 삭제
+		userRepository.deleteById(userId);
 	}
 }

--- a/src/main/java/org/sopt/homework/service/UserService.java
+++ b/src/main/java/org/sopt/homework/service/UserService.java
@@ -18,12 +18,12 @@ public class UserService {
 	}
 
 	@Transactional
-	public void createUser(UserSignupRequest userSignupRequest) {
+	public void createUser(final UserSignupRequest userSignupRequest) {
 		userRepository.save(userSignupRequest.toEntity());
 	}
 
 	@Transactional
-	public void deleteUser(long userId) {
+	public void deleteUser(final long userId) {
 		// 게시글과 유저의 연관관계 먼저 제거
 		postRepository.removeAuthor(userId);
 

--- a/src/main/java/org/sopt/homework/service/UserService.java
+++ b/src/main/java/org/sopt/homework/service/UserService.java
@@ -1,0 +1,21 @@
+package org.sopt.homework.service;
+
+import org.sopt.homework.dto.user.UserSignupRequest;
+import org.sopt.homework.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@Transactional
+	public void createUser(UserSignupRequest userSignupRequest) {
+		userRepository.save(userSignupRequest.toEntity());
+	}
+}


### PR DESCRIPTION
## 📝 과제 구현 결과

### 📌 필수 과제

- [x] 서비스에 유저를 추가해주세요.
- [x] 게시글은 기본적으로 제목과 내용을 가지고 있으면 좋겠어요. (단, 제목과 내용은 비어 있으면 안 돼요.)
- [x] 회원가입 기능을 추가해주세요.
- [x] 다음과 같은 API를 기본적으로 만들어주세요.
  - [x] 게시글 생성 API
  - [x] 게시글 전체 조회 API (최신 순으로 조회 / 제목과 게시글 작성자만 보일 수 있도록 해주세요.)
  - [x] 게시글 상세 조회 API (제목과 내용, 게시글 작성자가 모두 보이도록 해주세요.)
  - [x] 게시글 수정 API
  - [x] 게시글 삭제 API

### 🌟 선택 과제

- [x] 다음과 같은 제약 조건을 추가해주세요.
  - [x] 게시글의 제목은 30자를 넘지 않게 해주세요.
  - [x] 게시글의 내용은 1000자를 넘지 않게 해주세요.
  - [x] 유저의 이름(닉네임)은 10자를 넘지 않게 해주세요.
- [x] 검색 기능을 추가해주세요.
- [x] 게시글에 태그를 지정할 수 있으면 좋겠어요.
  - [x] 태그 기능을 추가하신다면, 태그를 기반으로 검색하는 기능도 추가해주세요.

### 💡 키워드 과제

<details>
<summary>ERD는 무엇이고, 어떻게 작성하나요? (ERD Cloud 같은 ERD 작성 툴 사용해보기)</summary>

## ERD?

ERD(Entity Relationship Diagram)는 데이터베이스를 설계하는 과정에서 사용되는 모델링 기법 중 하나로 데이터베이스에 저장될 데이터인 엔티티와 엔티티 간의 관계를 시각적으로 표현하는 다이어그램을 의미합니다.

ERD는 개체, 속성, 관계의 3가지 요소로 구성됩니다. 개체(Entity)는 테이블을 나타내며 ERD에서는 사각형을 표현됩니다. 속성(Attribute)은 테이블이 포함하고 있는 데이터의 타입과 이름 등을 나타내며 ERD에서는 타원으로 표현되고, 개체를 나타내는 사각형 안에 목록으로 작성되기도 합니다. 관계(Relationship)는 개체 간의 관계를 나타내며 마름모로 표현되고, 개체를 이어주는 화살표만을 이용하여 연관관계의 형태만을 표현하기도 합니다.

## 작성해보자

이번 과제에서는 ERDCloud를 이용하여 ERD를 작성했습니다.

ERD작성 결과는 아래와 같습니다.

<img width="791" alt="스크린샷 2025-05-01 오후 7 36 33" src="https://github.com/user-attachments/assets/3502fd99-9c4c-4ab7-8b96-05bedb20ba66" />

---

</details>

<details>
<summary>게시글을 100개 작성한 유저가 회원 탈퇴를 해본다고 할게요. 남는 게시글은 어떻게 처리해야 될까요?</summary>

## @ManyToOne과 @OneToMany

유저와 게시글은 1:N 형태의 연관관계를 가지게 됩니다. 일반적으로는 유저가 여러 개의 게시글을 작성할 수 있고, 게시글은 오직 한 명의 작성자만 가질 수 있기 때문입니다.

이 때 1:N 연관관계를 설정하는 방법은 `@ManyToOne`을 사용하는 방법과 `@OneToMany`를 사용하는 방법이 있습니다. 두 가지 방법 중에 어떤 것을 사용하는 지는 연관관계의 주인을 어떤 것으로 설정하느냐와 연관관계의 방향성 등에 따라 결정됩니다.

## 연관관계의 주인

연관관계의 주인은 데이터베이스에서는 외래키를 가지고 있는 쪽을 말하며, 자바에서는 참조 객체를 가지고 있는 쪽을 말합니다. 1:N 의 연관관계를 설정하기 위해서는 일반적으로 데이터베이스에서 N에 해당하는 쪽이 다른 쪽의 외래키를 참조하게 되며, 패러다임을 일치시키기 위해 자바에서도 참조 객체를 가지게 되고 연관관계의 주인이 됩니다. 그 이유는 데이터베이스가 저장하는 값이 원자값이어야 하며 여러 개의 값을 동시에 가질 수 없기 때문에 다수의 객체나 테이블을 한 번에 참조하는 방법을 사용할 수 없기 때문입니다.

1:N 연관관계에서 1쪽에 해강하는 테이블이 연관관계의 주인이 되는 것이 불가능한 것은 아니지만, 이러한 경우에 여러 개의 데이터에 대한 참조를 나타내기 위해 중복되는 값이 자식 테이블의 수만큼 발생하기 때문에 바람직 하지 않습니다.

따라서 1:N 연관관계를 구현하기 위해서는 보통 다수에 해당하는 엔티티의 필드에 참조 객체를 만들고 `@ManyToOne`을 사용하여 연관관계를 설정합니다.

## 연관관계의 방향 설정

데이터베이스에는 연관관계의 방향성이 존재하지 않습니다. 그 이유는 어느 한 쪽만 다른 한 쪽의 키를 외래키로 가지고 있으면 서로 조회가 가능하기 때문입니다. 하지만 자바에서는 연관관계가 객체를 참조하며 발생하므로 연관관계의 주인이 아닌 쪽에서는 다른 쪽의 객체에 접근할 수 없습니다.

따라서 필요한 경우에 자바에서는 양방향 연관관계에 대한 조치가 별도로 필요하며 이 경우에 참도에 의한 연관관계 설정을 연관관계에 있는 엔티티 둘다 적용하면 됩ㄴ다. 이번 과제의 경우에는 연관관계의 주인인 게시글에는 `@ManyToOne`을 사용하고 연관관계의 주인이 아닌 유저에는 `@OneToMany`를 사용하여 양방향 연관관계를 설정합니다.

## Cascade

엔티티와 테이블에 연관관계가 설정되면 두 객체는 생명주기에서도 결합도가 발생합니다. 그 이유는 바로 참조 무결성이라는 제약조건때문입니다. 참조 무결성은 자식 엔티티가 부모 엔티티를 참조하기 위해 가지고 있는 외래키가 참조할 수 없는 값을 가져서는 안된다는 제약조건입니다. 따라서 부모 엔티티의 키가 변경되거나 사라지면 자식 엔티티가 부모 엔티티를 참조할 수 없기 때문에 참조 무결성 조건을 위반하게 됩니다.

이를 방지하고자 cascade라는 속성이 존재합니다. cascade는 부모 엔티티의 생명주기와 자식 엔티티의 생명 주기를 어느 정도로 결합시키느냐에 대한 내용입니다. JPA에서 지원하는 cascade의 종류는 6가지가 있으며 이에 대한 내용은 아래와 같습니다.

- CascadeType.PERSIST

  엔티티를 영속화할 때 연관관계에 있는 엔티티도 함께 영속화하는 옵션입니다.

- CascadeType.MERGE

  엔티티의 상태가 변경되어 이전 엔티티의 상태에 병합할 때 연관관계에 있는 엔티티도 함께 병합을 진행하는 옵션입니다.

- CascadeType.REMOVE

  엔티티를 제거하면 연관관계에 있는 엔티티도 함께 삭제하는 옵션입니다.

- CascadeType.REFRESH

  영속성 컨텍스트의 엔티티 정보를 실제 데이터베이스의 값으로 새로고침하는 경우에 연관관계에 있는 엔티티도 함께 새로고침되는 옵션입니다.

- CascadeType.DETACH

  엔티티를 영속성 컨텍스트로부터 분리하여 준영속 상태로 전환할 때 연관관계에 있는 엔티티도 함께 준영속 상태로 전환되는 옵션입니다.

- CascadeType.ALL

  위의 다섯가지 cascade를 모두 적용한다는 옵션이다.

위의 내용은 데이터베이스의 cascade와는 조금 다른 느낌입니다. JPA가 제공하는 CascadeType은 대상이 엔티티와 연속성 컨텍스트이고, 데이터베이스의 cascade는 외래키를 가지고 있는 테이블에서 부모 엔티티의 수정, 삭제가 발생하였을 때 자식 엔티티를 어떻게 할 것인지에 대한 내용을 의미합니다.

## Fetch

연관관계가 설정되면서 연관관계에 있는 엔티티를 JPA를 이용하여 객체로 불러오는 과정에서도 결합도가 발생합니다. 이에 따라 연관관계가 설정된 엔티티를 불러오는 과정에서 연관관계에 있는 다른 엔티티를 어떻게 할 것인가에 대한 내용이 바로 fetch입니다.

fetch에는 두 가지 옵션이 존재하며 이에 대한 내용은 아래와 같습니다.

- FetchType.EAGER

  즉시로딩을 의미하며 엔티티를 조회할 때에 연관관계에 있는 엔티티까지 한 번에 조회한다는 것을 말합니다. 엔티티와 연관관계에 있는 엔티티가 반드시 같이 사용되는 경우에 주로 사용되며, `@ManyToOne`과 `@OneToOne`의 기본값으로 설정되어 있습니다.

- FetchType.LAZY

  지연로딩을 의미하며 연관관계에 있는 엔티티를 함께 조회하지 않고 실제로 사용할 때에 조회한다는 것을 말합니다. 엔티티와 연관관계에 있는 엔티티가 함께 사용되지 않는 경우에 주로 사용되며, `@OneToMany`와 `@ManyToMany`의 기본값으로 설정되어 있습니다.

## 그래서 유저가 탈퇴하면?

유저가 회원탈퇴를 하는 경우에 유저의 자식 테이블에 해당하는 게시글의 생명주기로 선택할 수 있는 방법은 두 가지 입니다. 첫번째는 부모 테이블의 생명주기와 같이 자식 테이블도 함께 소멸하는 것입니다. 이 방법은 게시글과 댓글의 관계처럼 자식 테이블의 데이터가 부모 테이블의 데이터에 완전히 종속적인 경우에 사용됩니다. 두번째 방법은 자식 테이블이 부모 데이블이 완전히 종속되지 않고 서비스 흐름 상에서 자식 테이블의 데이터가 독립적으로 사용될 수 있는 경우에 사용됩니다.

현재 사용할 수 있는 많은 서비스들에서 유저의 삭제가 발생해도 유저가 작성한 게시글이나 우저가 다른 게시글에 작성한 댓글, 채팅등에 대한 내용이 사라지지 않는 것을 확인할 수 있었습니다. 그 이유는 게시글이나 댓글, 채팅등이 아직 서비스를 이용 중인 다른 사용자들에게 제공되어야 하기 때문이라고 짐작해볼 수 있습니다.

이에 따라서 유저가 사라지더라도 서비스에 필요한 데이터는 사라지지 않는 것이 바람직 하며, 이를 위해 유저와 자식 엔티티의 연관관계를 삭제하고 유저에 대한 데이터를 삭제해야 하며 그 과정에서 자식 엔티티와 부모 엔티티의 생명주기를 관리하기 위해 cascade를 잘 활용하는 것이 중요하다고 생각합니다.

---

</details>

### 🤔 과제 회고

<details>
<summary>작성자가 없는 게시글을 만드는 방법</summary>

## 작성자 없는 게시글은 왜 생길까?

유저와 게시글이 1:N 연관관계를 가지게 되면서 부모 엔티티인 유저가 사라지면 해당 유저가 작성한 게시글인 자식 엔티티는 어떻게 관리해야하는지에 대해 고민했습니다. 실제 운영 중인 서비스들은 대부분 탈퇴한 사용자가 작성한 게시글이나 채팅에 대해 데이터를 삭제하기 보다는 사용자 정보만 삭제하는 방법을 사용 중이었습니다.

제 생각에는 게시글, 채팅 등과 같이 여러 사용자가 함께 조회 가능한 데이터는 아직 탈퇴하지 않고 서비스를 이용하는 사용자들에게 계속 제공되어야 하기 때문에 작성자 없는 게시글과 같은 데이터가 발생하는 것이라고 생각합니다.

## 어떻게 만들까?

유저와 게시글이 연관관계를 가지고 존재하는 상황에서 유저를 삭제하려고 하면 데이터베이스에서 에러가 발생합니다. 그 이유는 참조 무결성 제약조건 때문입니다. 참조 무결성은 자식 테이블이 외래키로 가지는 부모 테이블의 키가 참조할 수 없는 값을 가지면 안된다는 제약 조건입니다. 따라서 우리는 작성자가 없는 게시글을 만들기 위해 삭제하려는 유저가 작성한 게시글들의 외래키를 null로 변경한 뒤에 해당 유저를 삭제해야 합니다.

회원 탈퇴가 발생할 때에 게시글의 외래키를 null로 변경하는 방법에는 두 가지 정도가 존재합니다. 첫번째는 외래키에 `ON DELETE SET NULL`제약조건을 추가하는 것입니다. 제약조건을 추가하는 방법은 데이터베이스가 JPA를 거치지 않고 테이블을 관리하므로 성능이 좋다는 장점이 있지만, 모든 데이터베이스에서 지원하는 기능이 아니기 때문에 득정 데이터베이스에 종속적이며, JPA가 지원하지 않는 기능이기 때문에 코드 상에서 제어의 흐름이 명시되지 않는다는 문제가 있습니다.

두번째로는 JPA를 이용하여 직접 코드로 자식 엔티티의 참조값을 null로 변경하는 것입니다. 직접 코드로 구현하는 방법은 코드 상으로 제어의 흐름이 명확히 드러나고 득정 데이터베이스에 종속적이지 않다는 장점이 있지만, 데이터가 많을 수록 성능이 저하된다는 단점이 존재합니다.

## 그래서 어떤 걸 써야할까?

`ON DELETE SET NULL`제약조건을 추가하는 방법은 성능 상의 이점이 존재하나 가시성과 범용성이 떨어지고, 직접 구현하는 방법은 가시성과 범용성이 높아지지만 성능이 저하된다는 문제가 있습니다.

저는 가시성과 범용성이라는 이점을 가져가면서도 성능 저하를 줄이기 위해 JPA의 벌크 연산을 이용하여 구현하는 방법을 선택했습니다. 기존에 JPA가 제공하는 기능만을 사용하는 경우에는 삭제하려는 유저가 작성한 게시글을 모두 조회한 뒤에 외래키의 값을 하나하나 null로 변경하는 과정으로 연관관계 제거가 진행되었지만, 벌크연산을 이용하면 조회 과정 없이 update쿼리를 발생시킬 수 있고 변경 사항에 대한 조건을 통해 수정이 한 번에 가능하기 때문에 성능 저하를 최소화할 수 있다고 생각했습니다.

벌크연산을 사용하기 위해 `PostRespository`에 아래의 메서드를 추가합니다.

```java
@Modifying
@Query("UPDATE Post p SET p.author = null where p.author.id = :userId")
void removeAuthor(@Param("userId") long userId);
```

다음으로 유저가 삭제되는 과정에서 위의 메서드를 먼저 실행하여 연관관계를 제거한 뒤에 유저의 삭제를 진행합니다.

```java
@Transactional
public void deleteUser(long userId) {
	// 게시글과 유저의 연관관계 먼저 제거
	postRepository.removeAuthor(userId);

	// 유저 삭제
	userRepository.deleteById(userId);
}
```

위의 메서드를 실행한 결과 유저를 삭제하는 과정에서 연관관계 제거를 위한 update쿼리가 단 하나만 발생하였고, 유저가 삭제된 후에도 게시글의 외래키가 null로 설정되어 삭제되지 않는 것을 확인할 수 있었습니다.

실무에서는 어떤 방법을 사용하는지는 잘 모르고 데이터베이스의 제약조건을 사용하는 것 보다는 성능이 떨어질 수 있지만, 벌크연산을 통해 코드 상에서 연관관계의 제거를 명시하는 것이 협업 과정에서는 더 좋은 방법이라고 생각합니다.

---

</details>

<details>
<summary>검색 조건에 따른 검색 기능 분리?</summary>

## 검색, 어디까지 나눠야 할까?

검색 기능을 구현하면서 한 가지 궁금한 점이 생겼습니다. 바로 검색 조건에 따라 엔드포인트를 나누어야 하는 것인가에 대한 내용입니다. 사실 검색이라는 하나의 기능이지만 검색 조건에 따라 ~로 검색이라는 별도의 기능으로 해석될 여지도 존재하기 때문입니다. 하나의 엔드포인트로 만들자니 검색을 담당하는 메서드 안에서 검색 조건에 따라 조건문이 너무 많이 발생할 것 같고, 여러 엔드 포인트로 나누자니 검색 조건이 추가될 때마다 엔드포인트를 계속 추가해야 하고 여러 검색 조건을 한 번에 적용할 수 없다는 문제가 있습니다.

## 이번 과제에서는...

사실 제 생각에 이 문제는 서비스에 따라 달라지는 것이라고 생각합니다. 구현하려는 서비스의 검색기능에 대해 검색 조건이 많지 않고 여러 조건을 함께 사용하여 검색할 필요가 없다면 엔드 포인트를 나누는 것이 더 바람직하고, 검색 조건이 많거나 여러 검색 조건이 함께 사용된다면 하나의 엔드 포인트로 구현하는 것이 바람직하다고 생각합니다.

이번 과제에서는 다른 검색 조건이 추가될 수도 있고 여러 가지의 검색 조건이 함께 사용될 수 있을지도 모른다는 가정하에 하나의 엔드 포인트로 구현하였습니다. 하지만 그 과정에서 문제점이 하나 있었습니다. 클라이언트로부터 검색 조건으로 전달받은 파라미터의 상태에 따라 조건문이 엄청나게 많아진다는 것입니다. 이를 해결하고자 동적 쿼리를 사용하기 위해 자료 조사를 해보있습니다.

## 동적 쿼리와 정적 쿼리

동적 쿼리는 쿼리문이 데이터베이스를 조회하는 과정에서의 조건을 런타임에 결정할 수 있도록 하는 쿼리문 생성 방식을 의미합니다. 동적쿼리는 서비스 실행 과정에서 쿼리문에 필요한 여러가지 조건을 조합하거나 선택적으로 적용할 수 있어 유연하고 재사용성이 높으며 유지보수에 용이하다는 장점이 있습니다.

정적 쿼리는 쿼리문의 조건이 고정되어 컴파일 시점에 쿼리문을 생성하는 방식을 의미합니다. 사용 방식이 단순하고 직관적이기 때문에 조건이 변경되지 않는 경우에 기본적으로 사용됩니다.

보통 QueryDSL을 이용하여 정적 쿼리를 사용하지만 최대한 외부 라이브러리를 사용하지 말고 과제를 진행해달라는 파트장님의 이야기가 생각나서 JPA의 `JpaSpecificationExecutor`를 이용하여 동적 쿼리를 구현하고자 했습니다. 하지만 자료조사를 하다보니 `JpaSpecificationExecutor`를 이용하여 동적 쿼리를 생성하는 과정에서 여러가지 조건의 조합을 별도로 구현해야 했고 그 과정에서 조건문이 많이 발생한다는 문제를 해결하는 데에 큰 도움이 되지 않는다는 것을 알게 되었습니다. 물론 검색 조건이 추가되거나 변경되는 과정에서 정적 쿼리를 사용하는 것보다 더 유용하게 작용하겠지만, 큰 변경사항이 발생하지 않는 이상 정적 쿼리와 차이가 클 정도로 변경에서의 유연성이 장점이 될 것 같지 않다고 생각했습니다.

결과적으로 이번 과제에서는 정적 쿼리에 `OR`문을 이용하여 동적 쿼리처럼 동작하도록 구현하게 되었습니다. 결과적으로 검색 조건의 상태나 쿼리문의 조건을 조합하는 과정에서 발생하는 수많은 조건문에 대한 문제를 해결할 수 있었습니다. 또한 이를 통해서 검색 여러가지 검색 조건이 함께 동작하여 더 다양한 검색 조건을 활용할 수 있도록 구현할 수 있었습니다. 하지만 여전히 정적쿼리를 사용하면서 검색 조건의 변경에 따라 코드가 아닌 리터럴로 작성된 쿼리문을 변경해야하기 때문에 조금 더 공부를 해봐야 할 것 같습니다.

---

</details>